### PR TITLE
onMouseEnter is not triggered when Tilt is rendered under the mouse

### DIFF
--- a/src/tilt.js
+++ b/src/tilt.js
@@ -37,7 +37,13 @@ class Tilt extends Component {
     this.onMouseLeave = this.onMouseLeave.bind(this, this.props.onMouseLeave);
   }
   componentDidMount() {
-    this.element = findDOMNode(this)
+    this.element = findDOMNode(this);
+    var myNode = this.getDOMNode();
+    setTimeout(() => {
+      if (myNode.parentElement.querySelector(':hover') === myNode){
+        this.onMouseEnter();
+      }
+    }, 0);
   }
   componentWillUnmount() {
     clearTimeout(this.transitionTimeout);

--- a/src/tilt.js
+++ b/src/tilt.js
@@ -38,7 +38,7 @@ class Tilt extends Component {
   }
   componentDidMount() {
     this.element = findDOMNode(this);
-    var myNode = this.getDOMNode();
+    const myNode = this.getDOMNode();
     setTimeout(() => {
       if (myNode.parentElement.querySelector(':hover') === myNode){
         this.onMouseEnter();


### PR DESCRIPTION
When Tilt is rendered under the mouse, it's making the animation blocked on one side until onMouseEnter is triggered again.