### PR TITLE
Fix missing Repository field on npm page

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "description": "Tilt for React JS",
   "author": "Jonathan Dion <jonathandionalary@gmail.com> (https://github.com/jonathandion/)",
   "license": "MIT",
-  "repository": "jonathandion/react-tilt",
   "bugs": {
     "url": "https://github.com/jonathandion/react-tilt/issues"
   },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Tilt for React JS",
   "author": "Jonathan Dion <jonathandionalary@gmail.com> (https://github.com/jonathandion/)",
   "license": "MIT",
+  "repository": "jonathandion/react-tilt",
   "bugs": {
     "url": "https://github.com/jonathandion/react-tilt/issues"
   },

--- a/packages/react-tilt/package.json
+++ b/packages/react-tilt/package.json
@@ -4,6 +4,7 @@
   "description": "Tilt for React JS",
   "author": "Jonathan Dion <jonathandionalary@gmail.com> (https://github.com/jonathandion/)",
   "license": "MIT",
+  "repository": "jonathandion/react-tilt",
   "bugs": {
     "url": "https://github.com/jonathandion/react-tilt/issues"
   },


### PR DESCRIPTION
Add the missing Repository field in the right column on [the npm package page](https://www.npmjs.com/package/react-tilt):

<img width="1223" alt="Screenshot 2023-05-05 at 11 31 32" src="https://user-images.githubusercontent.com/1935696/236424060-1a48c977-db30-446c-8e59-ff577bca0c82.png">
